### PR TITLE
Wait for acre init before adding items to arsenal

### DIFF
--- a/addons/arsenal/XEH_preInit.sqf
+++ b/addons/arsenal/XEH_preInit.sqf
@@ -6,7 +6,14 @@ PREP_RECOMPILE_START;
 PREP_RECOMPILE_END;
 
 [QGVAR(addArsenal), {
-    [{!isNull player && {time > 1}}, {
+    [{
+        !isNull player
+        && {time > 1}
+        && {
+            !IS_MOD_LOADED(acre_main)
+            || {!isNil "acre_api_fnc_isInitialized" && {[] call acre_api_fnc_isInitialized}}
+        }
+    }, {
         params ["_object", "_items", "_addPlayerItems", "_categories"];
 
         TRACE_3("Adding local arsenal to object",_object,_addPlayerItems,_categories);


### PR DESCRIPTION
**When merged this pull request will:**
- title

Prevents issue where ItemRadio is added to arsenal instead of PRC343 when playing with ACRE.