### PR TITLE
Buildables - Fix area center position ASL instead of AGL

### DIFF
--- a/addons/buildables/functions/fnc_areaModule.sqf
+++ b/addons/buildables/functions/fnc_areaModule.sqf
@@ -22,7 +22,7 @@ params [
     ["_logic", objNull, [objNull]]
 ];
 
-private _area = [getPosASL _logic];
+private _area = [ASLToAGL getPosASL _logic];
 _area append (_logic getVariable ["objectarea", []]);
 _logic setVariable [QGVAR(area), _area, true];
 


### PR DESCRIPTION
**When merged this pull request will:**
- title

BIKI:
> position: Object or Array in format Position2D or Position3D (**must be PositionAGL if area is checked in 3D**)
